### PR TITLE
Add syntax highlight for INI file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ chrlauncher has feature for use portable Flash Player PPAPI.
 - open "chrlauncher.ini" and find "FlashPlayerPath" option and then set ".\Plugins\%flash_player_dll_name_here%"
 
 #### Settings:
-~~~
+~~~ini
 [chrlauncher]
 
 # Command line for Chromium (string):


### PR DESCRIPTION
Syntax highlight in the INI sample makes it more readable:

~~~ini
[chrlauncher]

# Command line for Chromium (string):
# See here: http://peter.sh/experiments/chromium-command-line-switches/
ChromiumCommandLine=--user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-component-update

# Chromium binaries directory (string):
ChromiumDirectory=.\bin

# Chromium binary file name (string):
ChromiumBinary=chrome.exe

# Adobe Flash Player PPAPI portable library path (string):
# Download here: http://effect8.ru/soft/media/adobe-flash-player-portable.html
FlashPlayerPath=.\plugins\pepflashplayer.dll

# Set Chromium binaries architecture (integer):
#
# 0	-> autodetect (default)
# 64	-> 64-bit
# 32	-> 32-bit
ChromiumArchitecture=0
~~~