### PR TITLE
chrlauncher.ini: Add begin and end marks to command line switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ chrlauncher has feature for use portable Flash Player PPAPI.
 
 # Command line for Chromium (string):
 # See here: https://peter.sh/experiments/chromium-command-line-switches/
-ChromiumCommandLine=--user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad
+ChromiumCommandLine=--flag-switches-begin --user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad --flag-switches-end
 
 # Chromium executable file name (string):
 ChromiumBinary=chrome.exe

--- a/bin/Readme.txt
+++ b/bin/Readme.txt
@@ -34,7 +34,7 @@ Settings:
 
 # Command line for Chromium (string):
 # See here: https://peter.sh/experiments/chromium-command-line-switches/
-ChromiumCommandLine=--user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad
+ChromiumCommandLine=--flag-switches-begin --user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad --flag-switches-end
 
 # Chromium executable file name (string):
 ChromiumBinary=chrome.exe

--- a/bin/chrlauncher.ini
+++ b/bin/chrlauncher.ini
@@ -5,7 +5,7 @@
 
 # Command line for Chromium (string):
 # See here: https://peter.sh/experiments/chromium-command-line-switches/
-ChromiumCommandLine=--user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad
+ChromiumCommandLine=--flag-switches-begin --user-data-dir=..\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad --flag-switches-end
 
 # Chromium executable file name (string):
 ChromiumBinary=chrome.exe

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,7 +241,7 @@ void init_browser_info (BROWSER_INFORMATION* pbi)
 
 	_r_str_copy (pbi->current_version, _countof (pbi->current_version), _app_getbinaryversion (pbi->binary_path));
 
-	_r_str_copy (pbi->args, _countof (pbi->args), app.ConfigGet (L"ChromiumCommandLine", L"--user-data-dir=..\\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad"));
+	_r_str_copy (pbi->args, _countof (pbi->args), app.ConfigGet (L"ChromiumCommandLine", L"--flag-switches-begin --user-data-dir=..\\profile --no-default-browser-check --allow-outdated-plugins --disable-logging --disable-breakpad --flag-switches-end"));
 
 	// parse command line
 	{


### PR DESCRIPTION
Add "--flag-switches-begin" before, and "--flag-switches-end" after
the command line switches set by chrlauncher. This way, we can easily
distinguish between the chrlauncher switches, and possibly other
switches, e.g. those set by launching "chrlauncher.exe --flag-switch"
manually from command line by the user.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>